### PR TITLE
Feature/#49 video api exception handling

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -52,18 +52,18 @@ ENGINE = InnoDB;
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `youtube_clone`.`subscribe` (
   `subscribe_id` BIGINT(20) NOT NULL,
-  `subscriber` BIGINT(20) NOT NULL,
-  `channel` BIGINT(20) NOT NULL,
+  `subscriber_id` BIGINT(20) NOT NULL,
+  `channel_id` BIGINT(20) NOT NULL,
   PRIMARY KEY (`subscribe_id`),
-  INDEX `fk_subscribe_channel1_idx` (`subscriber` ASC) VISIBLE,
-  INDEX `fk_subscribe_channel2_idx` (`channel` ASC) VISIBLE,
+  INDEX `fk_subscribe_channel1_idx` (`subscriber_id` ASC) VISIBLE,
+  INDEX `fk_subscribe_channel2_idx` (`channel_id` ASC) VISIBLE,
   CONSTRAINT `fk_subscribe_channel1`
-    FOREIGN KEY (`subscriber`)
+    FOREIGN KEY (`subscriber_id`)
     REFERENCES `youtube_clone`.`channel` (`channel_id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION,
   CONSTRAINT `fk_subscribe_channel2`
-    FOREIGN KEY (`channel`)
+    FOREIGN KEY (`channel_id`)
     REFERENCES `youtube_clone`.`channel` (`channel_id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION)
@@ -82,7 +82,8 @@ CREATE TABLE IF NOT EXISTS `youtube_clone`.`video` (
   `updated_time` DATETIME NOT NULL,
   `view_count` INT NOT NULL,
   `channel_id` BIGINT(20) NOT NULL,
-  `status` ENUM('public', 'private', 'draft') NOT NULL,
+  `video_sec` BIGINT DEFAULT 0,
+  `status` ENUM('PUBLIC', 'PRIVATE', 'DRAFT') NOT NULL,
   PRIMARY KEY (`video_id`),
   INDEX `fk_video_info_channel1_idx` (`channel_id` ASC) VISIBLE,
   CONSTRAINT `fk_video_info_channel1`

--- a/database.sql
+++ b/database.sql
@@ -52,18 +52,18 @@ ENGINE = InnoDB;
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `youtube_clone`.`subscribe` (
   `subscribe_id` BIGINT(20) NOT NULL,
-  `subscriber_id` BIGINT(20) NOT NULL,
-  `channel_id` BIGINT(20) NOT NULL,
+  `subscriber` BIGINT(20) NOT NULL,
+  `channel` BIGINT(20) NOT NULL,
   PRIMARY KEY (`subscribe_id`),
-  INDEX `fk_subscribe_channel1_idx` (`subscriber_id` ASC) VISIBLE,
-  INDEX `fk_subscribe_channel2_idx` (`channel_id` ASC) VISIBLE,
+  INDEX `fk_subscribe_channel1_idx` (`subscriber` ASC) VISIBLE,
+  INDEX `fk_subscribe_channel2_idx` (`channel` ASC) VISIBLE,
   CONSTRAINT `fk_subscribe_channel1`
-    FOREIGN KEY (`subscriber_id`)
+    FOREIGN KEY (`subscriber`)
     REFERENCES `youtube_clone`.`channel` (`channel_id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION,
   CONSTRAINT `fk_subscribe_channel2`
-    FOREIGN KEY (`channel_id`)
+    FOREIGN KEY (`channel`)
     REFERENCES `youtube_clone`.`channel` (`channel_id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION)
@@ -82,8 +82,7 @@ CREATE TABLE IF NOT EXISTS `youtube_clone`.`video` (
   `updated_time` DATETIME NOT NULL,
   `view_count` INT NOT NULL,
   `channel_id` BIGINT(20) NOT NULL,
-  `video_sec` BIGINT DEFAULT 0,
-  `status` ENUM('PUBLIC', 'PRIVATE', 'DRAFT') NOT NULL,
+  `status` ENUM('public', 'private', 'draft') NOT NULL,
   PRIMARY KEY (`video_id`),
   INDEX `fk_video_info_channel1_idx` (`channel_id` ASC) VISIBLE,
   CONSTRAINT `fk_video_info_channel1`

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/domain/Video.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/domain/Video.java
@@ -1,7 +1,6 @@
 package com.semtleWebGroup.youtubeclone.domain.video.domain;
 
 import com.semtleWebGroup.youtubeclone.domain.channel.domain.Channel;
-import com.semtleWebGroup.youtubeclone.domain.video_media.service.MediaServerSpokesman;
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;
@@ -19,6 +18,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 public class Video {
+    public enum VideoStatus{PUBLIC, PRIVATE, DRAFT};
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name="uuid2", strategy = "uuid2")
@@ -26,12 +26,10 @@ public class Video {
     private UUID id;
 
     @Column(length=45)
-    private String title;
+    private String title = "";
 
     @Column(length=45)
-    private String description;
-
-    private Blob thumbImg;
+    private String description = "";
 
     @CreatedDate
     private LocalDateTime createdTime;
@@ -39,11 +37,12 @@ public class Video {
     @LastModifiedDate
     private LocalDateTime updatedTime;
 
-    private int viewCount;
+    private int viewCount = 0;
 
-    private Long videoSec;
+    private Long videoSec = 0L;
 
-    private MediaServerSpokesman.EncodingStatus status;
+    @Enumerated(EnumType.STRING)
+    private VideoStatus status = VideoStatus.DRAFT;
 
     @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "video")
     private Set<VideoLike> likes = new HashSet<>();
@@ -54,15 +53,9 @@ public class Video {
 
     @Builder
     public Video(Channel channel) {
-        this.viewCount = 0;
         this.createdTime = LocalDateTime.now();
         this.updatedTime = LocalDateTime.now();
         this.channel = channel;
-    }
-
-    public void update(String title, String description, Blob thumbImg) {
-        this.update(title, description);
-        this.thumbImg = thumbImg;
     }
 
     public void update(String title, String description) {

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/domain/Video.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/domain/Video.java
@@ -42,7 +42,7 @@ public class Video {
     private Long videoSec = 0L;
 
     @Enumerated(EnumType.STRING)
-    private VideoStatus status = VideoStatus.DRAFT;
+    private VideoStatus status = VideoStatus.PUBLIC; // 추후 디폴트 값은 DRAFT로 변경하고, PUBLIC/PRIVATE로 전환하는 기능 추가 필요.
 
     @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "video")
     private Set<VideoLike> likes = new HashSet<>();

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/dto/VideoEditDto.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/dto/VideoEditDto.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Blob;
 import java.util.UUID;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,15 +14,13 @@ public class VideoEditDto {
     private UUID videoId;
     private String title;
     private String description;
-    private Blob thumbImg;
     private Channel channel;
 
     @Builder
-    public VideoEditDto(Channel channel, UUID videoId, String title, String description, Blob thumbImg) {
+    public VideoEditDto(Channel channel, UUID videoId, String title, String description) {
         this.channel = channel;
         this.videoId = videoId;
         this.title = title;
         this.description = description;
-        this.thumbImg = thumbImg;
     }
 }

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/dto/VideoListResponse.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/dto/VideoListResponse.java
@@ -17,9 +17,8 @@ import java.util.UUID;
 public class VideoListResponse {
 
     private UUID id;
-    private String title;
 
-    private byte[] thumbImg;
+    private String title;
 
     private byte[] channelImg;
 
@@ -35,7 +34,6 @@ public class VideoListResponse {
     public VideoListResponse(Video video) {
         this.id = video.getId();
         this.title = video.getTitle();
-        this.thumbImg = convertBlobToBytes(video.getThumbImg());
         this.channelImg = convertBlobToBytes(video.getChannel().getChannelImage());
         this.channelName = video.getChannel().getTitle();
         this.viewCount = video.getViewCount();

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/exception/ForbiddenException.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/exception/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.semtleWebGroup.youtubeclone.domain.video.exception;
+
+import com.semtleWebGroup.youtubeclone.global.error.ErrorCode;
+import com.semtleWebGroup.youtubeclone.global.error.exception.BusinessException;
+
+public class ForbiddenException extends BusinessException {
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/repository/VideoRepository.java
@@ -11,4 +11,6 @@ import java.util.UUID;
 public interface VideoRepository extends JpaRepository<Video, UUID> {
     List<Video> findByTitleContaining(String key);
     Page<Video> findAllByOrderByCreatedTimeDesc(Pageable pageable);
+
+    Page<Video> findByStatusOrderByCreatedTimeDesc(Pageable pageable, Video.VideoStatus status);
 }

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/service/VideoService.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/service/VideoService.java
@@ -3,17 +3,17 @@ package com.semtleWebGroup.youtubeclone.domain.video.service;
 import com.semtleWebGroup.youtubeclone.domain.channel.domain.Channel;
 import com.semtleWebGroup.youtubeclone.domain.video.domain.Video;
 import com.semtleWebGroup.youtubeclone.domain.video.dto.*;
+import com.semtleWebGroup.youtubeclone.domain.video.exception.ForbiddenException;
 import com.semtleWebGroup.youtubeclone.domain.video.repository.VideoRepository;
 import com.semtleWebGroup.youtubeclone.domain.video_media.service.MediaServerSpokesman;
+import com.semtleWebGroup.youtubeclone.global.error.ErrorCode;
 import com.semtleWebGroup.youtubeclone.global.error.exception.EntityNotFoundException;
-import com.semtleWebGroup.youtubeclone.global.error.exception.MediaServerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -22,8 +22,9 @@ public class VideoService {
     private final VideoRepository videoRepository;
     private final MediaServerSpokesman mediaServerSpokesman;
 
-    public void save(Video video) {
-        videoRepository.save(video);
+    private void checkAuthority(Video video, Channel channel) {
+        if (video.getChannel().getId() != channel.getId())
+            throw new ForbiddenException(ErrorCode.ACCESS_DENIED);
     }
 
     public Video getVideo(UUID videoId) {
@@ -32,17 +33,17 @@ public class VideoService {
         return video;
     }
 
+    public void save(Video video) {
+        videoRepository.save(video);
+    }
+
+    @Transactional
     public VideoResponse upload(VideoUploadDto dto) {
         Video video = Video.builder()
                 .channel(dto.getChannel())
                 .build();
         videoRepository.save(video);
-        try {
-            mediaServerSpokesman.sendEncodingRequest(dto.getVideoFile(), video.getId(), dto.getThumbImg());
-        } catch (MediaServerException e) {
-            // TODO
-        }
-
+        mediaServerSpokesman.sendEncodingRequest(dto.getVideoFile(), video.getId(), dto.getThumbImg());
         return new VideoResponse(video);
     }
 
@@ -63,25 +64,19 @@ public class VideoService {
     @Transactional
     public VideoResponse edit(VideoEditDto dto) {
         Video video = this.getVideo(dto.getVideoId());
-        // TODO: 권한 확인
-        if (dto.getThumbImg() == null)
-            video.update(dto.getTitle(), dto.getDescription());
-        else
-            video.update(dto.getTitle(), dto.getDescription(), dto.getThumbImg());
+        checkAuthority(video, dto.getChannel());
+        video.update(dto.getTitle(), dto.getDescription());
         videoRepository.save(video);
         return new VideoResponse(video);
     }
 
     @Transactional
     public VideoResponse delete(UUID videoId, Channel channel) {
-        // TODO: 권한 확인
-        try {
-            mediaServerSpokesman.deleteVideo(videoId);
-        } catch (MediaServerException e) {
-            // TODO
-        }
-
         Video video = this.getVideo(videoId);
+        checkAuthority(video, channel);
+
+        mediaServerSpokesman.deleteVideo(videoId);
+
         videoRepository.delete(video);
         return new VideoResponse(video);
     }

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/service/MediaServerSpokesman.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/service/MediaServerSpokesman.java
@@ -1,5 +1,6 @@
 package com.semtleWebGroup.youtubeclone.domain.video_media.service;
 
+import com.semtleWebGroup.youtubeclone.global.error.FieldError;
 import com.semtleWebGroup.youtubeclone.global.error.exception.MediaServerException;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.lang.Nullable;

--- a/src/main/java/com/semtleWebGroup/youtubeclone/global/error/exception/BadRequestException.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/global/error/exception/BadRequestException.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * 클라이언트의 잘못된 요청
  */
-public class BadRequestException extends RuntimeException{
+public class BadRequestException extends RuntimeException {
 
     private ErrorCode errorCode;
     private List<FieldError> fieldErrors;

--- a/src/main/java/com/semtleWebGroup/youtubeclone/global/error/exception/EntityNotFoundException.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/global/error/exception/EntityNotFoundException.java
@@ -2,7 +2,7 @@ package com.semtleWebGroup.youtubeclone.global.error.exception;
 
 import com.semtleWebGroup.youtubeclone.global.error.ErrorCode;
 
-public class EntityNotFoundException extends BusinessException{
+public class EntityNotFoundException extends BusinessException {
     public EntityNotFoundException(String message){
         super(message, ErrorCode.ENTITY_NOT_FOUND);
     }

--- a/src/main/java/com/semtleWebGroup/youtubeclone/global/error/exception/MediaServerException.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/global/error/exception/MediaServerException.java
@@ -1,4 +1,4 @@
 package com.semtleWebGroup.youtubeclone.global.error.exception;
 
-public class MediaServerException extends Exception{
+public class MediaServerException extends RuntimeException {
 }


### PR DESCRIPTION
# 변경 유형

- [ ] 기능 추가
- [X] 성능 개선 ( 리팩토링 )
- [ ] 오류 수정
- [ ] Test Case 추가
- [ ] 기타 (document, 환경설정, CI/CD )

# 변경 내용
- 예외처리 추가
- video status enum 변경 (대문자로)
  - 이 외에도 sql이랑 다른 필드가 다른 테이블에 많기 때문에 조정이 필요합니다.
  - deploy 작업 할 때 deploy branch에서 한 번 수정했었는데 여기에는 (당연하게도) 없네요.. TT
- 추후 status 관련 로직 추가 필요
  - 현재는 PUBLIC을 default로 설정 (변경 로직이 없는데, 조회 시 PUBLIC 데이터만 조회해야 하므로 테스트 용으로 설정)
- enum 값으로 video 찾는 부분 수정 필요
  - 현재 단순히 `Video.VideoStatus.PUBLIC` 을 인자로 넘겨주면 조회 되지 않음

# 참조 자료

Closes #49 