### PR TITLE
Feature/#53 media server connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/domain/Video.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video/domain/Video.java
@@ -1,6 +1,8 @@
 package com.semtleWebGroup.youtubeclone.domain.video.domain;
 
 import com.semtleWebGroup.youtubeclone.domain.channel.domain.Channel;
+import com.semtleWebGroup.youtubeclone.domain.video_media.dto.response.GetEncodingStatusResponse;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.ProdMediaServerSpokesman;
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/aop/MediaServerApiLogger.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/aop/MediaServerApiLogger.java
@@ -1,0 +1,41 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Slf4j
+@Aspect
+@Configuration
+@EnableAspectJAutoProxy
+public class MediaServerApiLogger {
+
+
+    //pointcut : video_media.service 패키지 안에 있으면서, MediaServerSpokesman 인터페이스를 구현한 클래스의 모든 메소드에 적용
+    @Pointcut("execution(* com.semtleWebGroup.youtubeclone.domain.video_media.service.*.*(..)) && target(com.semtleWebGroup.youtubeclone.domain.video_media.service.MediaServerSpokesman)")
+    private void publicApiRequest() {
+    }
+
+    @Around("publicApiRequest()")
+    public Object doLog(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        log.debug("AOP LOG :: MediaServerSpokesman method called: {}", proceedingJoinPoint.getSignature().toLongString());
+        Object proceed = proceedingJoinPoint.proceed();
+        log.debug("AOP LOG ::MediaServerSpokesman method finished: {}", proceedingJoinPoint.getSignature().toLongString());
+        return proceed;
+    }
+
+    @AfterThrowing(pointcut = "publicApiRequest()", throwing = "e")
+    public void doLogAfterThrowing(JoinPoint joinPoint, Throwable e) throws Throwable {
+        log.error("AOP LOG ::MediaServerSpokesman method failed: {}", joinPoint.getSignature().toLongString(), e);
+        throw e;
+    }
+
+
+
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/config/MediaServerConnectionConfig.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/config/MediaServerConnectionConfig.java
@@ -1,0 +1,29 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.config;
+
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.MediaServerSpokesman;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.MockedMediaServerSpokesman;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.ProdMediaServerSpokesman;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.util.Assert;
+
+@Configuration
+public class MediaServerConnectionConfig {
+
+    @Profile({"dev", "test"})
+    @Bean
+    public MediaServerSpokesman devMediaServerSpokesman(){
+        return new MockedMediaServerSpokesman();
+    }
+
+    @Profile("prod")
+    @Bean
+    public MediaServerSpokesman prodMediaServerSpokesman(Environment environment){
+        // application-prod.yml에 media-server.url이 설정되어 있어야 한다.
+        String mediaServerUrl = environment.getProperty("media-server.url");
+        Assert.notNull(mediaServerUrl, "media-server.url must not be null on prod profile");
+        return new ProdMediaServerSpokesman(mediaServerUrl);
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/dto/request/ThumbnailPatchRequest.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/dto/request/ThumbnailPatchRequest.java
@@ -1,0 +1,21 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.dto.request;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+public class ThumbnailPatchRequest extends HttpEntity<MultiValueMap<String, Object>> {
+    private ThumbnailPatchRequest(MultiValueMap<String, Object> headers) {
+        super(headers);
+    }
+
+    public static ThumbnailPatchRequest of(UUID videoId, MultipartFile thumbnail){
+        MultiValueMap<String, Object> body = new org.springframework.util.LinkedMultiValueMap<>();
+        body.add("videoId", videoId.toString());
+        body.add("thumbnail", thumbnail.getResource());
+        return new ThumbnailPatchRequest(body);
+    }
+
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/dto/request/VodInitPostRequest.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/dto/request/VodInitPostRequest.java
@@ -1,0 +1,29 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.dto.request;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+
+public class VodInitPostRequest extends HttpEntity<MultiValueMap<String, Object>> {
+
+//    public VodInitPostRequest(String url, MultipartFile videoFile, @Nullable MultipartFile thumbnailFile) {
+//        super(body);
+//        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+//        body.add("videoFile", videoFile.getResource());
+//        if (thumbnailFile != null) body.add("thumbnailFile", thumbnailFile.getResource());
+//
+//    }
+
+    protected VodInitPostRequest(MultiValueMap<String, Object> headers) {
+        super(headers);
+    }
+
+    public static VodInitPostRequest of(MultipartFile videoFile, @Nullable MultipartFile thumbnailFile) {
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("videoFile", videoFile.getResource());
+        if (thumbnailFile != null) body.add("thumbnailFile", thumbnailFile.getResource());
+        return new VodInitPostRequest(body);
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/dto/response/GetEncodingStatusResponse.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/dto/response/GetEncodingStatusResponse.java
@@ -1,0 +1,18 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.dto.response;
+
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.MediaServerSpokesman;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class GetEncodingStatusResponse {
+    public enum EncodingStatus {WAIT, RUNNING, FINISHED, ERROR}
+    public enum MediaType {VIDEO, THUMBNAIL};
+    private EncodingStatus entireJobStatus;
+    private Map<MediaType , EncodingStatus> statusMap;
+
+
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/dto/response/VodInitPostResponse.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/dto/response/VodInitPostResponse.java
@@ -1,0 +1,16 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VodInitPostResponse {
+    private String videoId;
+    private String message;
+
+    //비디오 길이 (초 단위)
+    private double videoLength;
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/service/MediaServerSpokesman.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/service/MediaServerSpokesman.java
@@ -1,67 +1,52 @@
 package com.semtleWebGroup.youtubeclone.domain.video_media.service;
 
 import com.semtleWebGroup.youtubeclone.global.error.FieldError;
+import com.semtleWebGroup.youtubeclone.domain.video_media.dto.response.GetEncodingStatusResponse;
 import com.semtleWebGroup.youtubeclone.global.error.exception.MediaServerException;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
-/**
- * 미디어 서버와 통신을 중계해 주는 api <br>
- * 추상화를 통해 제공 되는 메서드로 미디어 서버와 통신할 수 있게 함
- */
-@Service
-public class MediaServerSpokesman {
-
-    public enum EncodingStatus{WAIT, RUNNING, FINISHED, ERROR};
-
+public interface MediaServerSpokesman {
     /**
      * 미디어 서버와 통신을 중계해 주는 api
-     * @param videoFile 비디오 파일
-     * @param videoId 비디오 아이디
+     *
+     * @param videoFile     비디오 파일
+     * @param videoId       비디오 아이디
      * @param thumbnailFile 썸네일 파일 (없으면 null)
+     * @return
      * @throws MediaServerException 미디어 서버의 응답이 200이 아닐 경우
      * @implNote 비디오 파일과 비디오 아이디는 필수 인자이고, 썸네일 파일은 없을 시 미디어 서버에서 첫 프레임을 썸네일로 지정함 <br>
      * 이 메서드는 비동기 적으로 처리되며, ok 사인은 인코딩이 완료 됨을 의미하지 않고, 쓰레드 풀의 대기열에 잘 등록됬다는 것을 의미함.
      */
-    public void sendEncodingRequest(MultipartFile videoFile, UUID videoId, @Nullable MultipartFile thumbnailFile) throws MediaServerException {
-        Assert.notNull(videoFile,"videoFile must not be null");
-        Assert.notNull(videoId,"videoId must not be null");
-    }
+    double sendEncodingRequest(MultipartFile videoFile, UUID videoId, @Nullable MultipartFile thumbnailFile) throws MediaServerException;
 
     /**
      * 인코딩 큐에 등록된 비디오의 인코딩 상태를 가져옴
+     *
      * @param videoId 비디오 아이디
      * @return 인코딩 상태
      * @throws MediaServerException 미디어 서버의 응답 중 문제가 생겼을 경우
      */
-    public EncodingStatus getEncodingStatus(UUID videoId) throws MediaServerException {
-        Assert.notNull(videoId,"videoId must not be null");
-        return EncodingStatus.FINISHED;
-    }
+    GetEncodingStatusResponse.EncodingStatus getEncodingStatus(UUID videoId) throws MediaServerException;
 
     /**
      * 비디오 삭제를 요청함
+     *
      * @param videoId 비디오 아이디
      * @throws MediaServerException 미디어 서버의 응답 중 문제가 생겼을 경우
      */
-    public void deleteVideo(UUID videoId) throws MediaServerException {
-        Assert.notNull(videoId,"videoId must not be null");
-    }
+    void deleteVideo(UUID videoId) throws MediaServerException;
 
     /**
      * 썸네일을 업데이트 함
+     *
      * @param videoId
      * @param thumbnailFile
      * @throws MediaServerException
      */
-    public void patchThumbnail(UUID videoId, FilePart thumbnailFile) throws MediaServerException {
-        Assert.notNull(videoId,"videoId must not be null");
-        Assert.notNull(thumbnailFile,"thumbnailFile must not be null");
-    }
+    void patchThumbnail(UUID videoId, MultipartFile thumbnailFile) throws MediaServerException;
 
 }

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/service/MockedMediaServerSpokesman.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/service/MockedMediaServerSpokesman.java
@@ -1,0 +1,39 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.service;
+
+import com.semtleWebGroup.youtubeclone.domain.video_media.dto.response.GetEncodingStatusResponse;
+import com.semtleWebGroup.youtubeclone.global.error.exception.MediaServerException;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+public class MockedMediaServerSpokesman implements MediaServerSpokesman {
+
+    @Override
+    public double sendEncodingRequest(MultipartFile videoFile, UUID videoId, @Nullable MultipartFile thumbnailFile) throws MediaServerException {
+        Assert.notNull(videoFile, "videoFile must not be null");
+        Assert.notNull(videoId, "videoId must not be null");
+        return 100.0;
+    }
+
+    @Override
+    public GetEncodingStatusResponse.EncodingStatus getEncodingStatus(UUID videoId) throws MediaServerException {
+        Assert.notNull(videoId,"videoId must not be null");
+        return GetEncodingStatusResponse.EncodingStatus.FINISHED;
+    }
+
+    @Override
+    public void deleteVideo(UUID videoId) throws MediaServerException {
+        Assert.notNull(videoId,"videoId must not be null");
+
+    }
+
+    @Override
+    public void patchThumbnail(UUID videoId, MultipartFile thumbnailFile) throws MediaServerException {
+        Assert.notNull(videoId,"videoId must not be null");
+        Assert.notNull(thumbnailFile,"thumbnailFile must not be null");
+
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/service/ProdMediaServerSpokesman.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/video_media/service/ProdMediaServerSpokesman.java
@@ -1,0 +1,142 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.service;
+
+import com.semtleWebGroup.youtubeclone.domain.video_media.dto.request.ThumbnailPatchRequest;
+import com.semtleWebGroup.youtubeclone.domain.video_media.dto.request.VodInitPostRequest;
+import com.semtleWebGroup.youtubeclone.domain.video_media.dto.response.GetEncodingStatusResponse;
+import com.semtleWebGroup.youtubeclone.domain.video_media.dto.response.VodInitPostResponse;
+import com.semtleWebGroup.youtubeclone.global.error.exception.MediaServerException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.*;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+/**
+ * 운영 배포환경 전용 미디어 서버 중계 서비스
+ */
+@Slf4j
+public class ProdMediaServerSpokesman implements MediaServerSpokesman {
+
+    private final String mediaServerUrl;
+
+    private final RestTemplate restTemplate;
+
+    public ProdMediaServerSpokesman(String mediaServerUrl) {
+        this.mediaServerUrl = mediaServerUrl;
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Override
+    public double sendEncodingRequest(MultipartFile videoFile, UUID videoId, @Nullable MultipartFile thumbnailFile) throws MediaServerException {
+        Assert.notNull(videoFile, "videoFile must not be null");
+        Assert.notNull(videoId, "videoId must not be null");
+
+        //요소 정의
+        String url = String.format("%s/media/vods/%s", mediaServerUrl, videoId);
+        log.debug("send encoding request to media server. url: {}", url);
+
+        VodInitPostRequest httpRequest = VodInitPostRequest.of(videoFile, thumbnailFile);
+
+        //미디어 서버와 통신
+        ResponseEntity<VodInitPostResponse> response = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(httpRequest), VodInitPostResponse.class);
+        log.debug("response from media server: {}", response);
+
+        //응답 확인
+        HttpStatus statusCode = response.getStatusCode();
+
+        if (response.getBody() == null) {
+            //To-Do 예외 처리
+            throw new MediaServerException();
+        } else if (statusCode == HttpStatus.OK) {
+            return response.getBody().getVideoLength();
+        } else if (statusCode == HttpStatus.BAD_REQUEST) {
+            //To-Do 예외처리
+            throw new MediaServerException();
+        } else {
+            //To-Do 예외처리
+            throw new MediaServerException();
+        }
+    }
+
+    @Override
+    public GetEncodingStatusResponse.EncodingStatus getEncodingStatus(UUID videoId) throws MediaServerException {
+        Assert.notNull(videoId,"videoId must not be null");
+
+        String url = String.format("%s/media/vods/%s/encoding/status", mediaServerUrl, videoId);
+
+        ResponseEntity<GetEncodingStatusResponse> response = restTemplate.exchange(url, HttpMethod.GET, HttpEntity.EMPTY, GetEncodingStatusResponse.class);
+
+        HttpStatus statusCode = response.getStatusCode();
+
+        if (response.getBody() == null) {
+            //To-Do 예외 처리
+            throw new MediaServerException();
+        } else if (statusCode == HttpStatus.OK) {
+            return response.getBody().getEntireJobStatus();
+        } else if (statusCode == HttpStatus.BAD_REQUEST) {
+            //To-Do 예외처리
+            throw new MediaServerException();
+        } else {
+            //To-Do 예외처리
+            throw new MediaServerException();
+        }
+    }
+
+    @Override
+    public void deleteVideo(UUID videoId) throws MediaServerException {
+        Assert.notNull(videoId,"videoId must not be null");
+
+        String url = String.format("%s/media/vods/%s", mediaServerUrl, videoId);
+
+        ResponseEntity<Void> response = restTemplate.exchange(url, HttpMethod.DELETE, HttpEntity.EMPTY, Void.class);
+
+        HttpStatus statusCode = response.getStatusCode();
+
+        if (statusCode == HttpStatus.OK) {
+            return;
+        } else if (statusCode == HttpStatus.BAD_REQUEST) {
+            //To-Do 예외처리
+            throw new MediaServerException();
+        } else {
+            //To-Do 예외처리
+            throw new MediaServerException();
+        }
+
+    }
+
+    @Override
+    public void patchThumbnail(UUID videoId, MultipartFile thumbnailFile) throws MediaServerException {
+        Assert.notNull(videoId,"videoId must not be null");
+        Assert.notNull(thumbnailFile,"thumbnailFile must not be null");
+
+        String url = String.format("%s/media/vods/%s/thumbnail", mediaServerUrl, videoId);
+
+        ThumbnailPatchRequest body = ThumbnailPatchRequest.of(videoId, thumbnailFile);
+
+        ResponseEntity<Void> response = restTemplate.exchange(url, HttpMethod.PATCH, body, Void.class);
+
+        HttpStatus statusCode = response.getStatusCode();
+
+        if (statusCode == HttpStatus.OK) {
+            return;
+        } else if (statusCode == HttpStatus.BAD_REQUEST) {
+            //To-Do 예외처리
+            throw new MediaServerException();
+        } else {
+            //To-Do 예외처리
+            throw new MediaServerException();
+        }
+
+
+
+    }
+
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,4 +17,4 @@ logging:
     root: error
 # 미디어 서버와 통신하기 위한 url : ex) http://localhost:8080
 media-server:
-  url: {media-server-url}
+  url: ${media-server-url}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,3 +15,6 @@ spring:
 logging:
   level:
     root: error
+# 미디어 서버와 통신하기 위한 url : ex) http://localhost:8080
+media-server:
+  url: {media-server-url}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,6 @@
 spring:
   profiles:
     active: # dev, test, alpha, prod
-      - dev
+      - prod
     include:
       - common-setting

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,6 @@
 spring:
   profiles:
     active: # dev, test, alpha, prod
-      - prod
+      - dev
     include:
       - common-setting

--- a/src/test/java/com/semtleWebGroup/youtubeclone/domain/video/application/VideoLikeServiceTest.java
+++ b/src/test/java/com/semtleWebGroup/youtubeclone/domain/video/application/VideoLikeServiceTest.java
@@ -10,6 +10,8 @@ import com.semtleWebGroup.youtubeclone.domain.video.repository.VideoRepository;
 import com.semtleWebGroup.youtubeclone.domain.video.service.VideoLikeService;
 import com.semtleWebGroup.youtubeclone.domain.video.service.VideoService;
 import com.semtleWebGroup.youtubeclone.domain.video_media.service.MediaServerSpokesman;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.MockedMediaServerSpokesman;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.ProdMediaServerSpokesman;
 import com.semtleWebGroup.youtubeclone.test_super.MockTest;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
@@ -33,7 +35,7 @@ public class VideoLikeServiceTest extends MockTest {
         channelRepository = Mockito.mock(ChannelRepository.class);
         videoRepository = Mockito.mock(VideoRepository.class);
         videoLikeRepository = Mockito.mock(VideoLikeRepository.class);
-        MediaServerSpokesman mediaServerSpokesman = new MediaServerSpokesman();
+        MediaServerSpokesman mediaServerSpokesman = new MockedMediaServerSpokesman();
         videoService = new VideoService(videoRepository, mediaServerSpokesman);
         videoLikeService = new VideoLikeService(videoLikeRepository, videoService);
     }

--- a/src/test/java/com/semtleWebGroup/youtubeclone/domain/video/application/VideoServiceTest.java
+++ b/src/test/java/com/semtleWebGroup/youtubeclone/domain/video/application/VideoServiceTest.java
@@ -7,6 +7,8 @@ import com.semtleWebGroup.youtubeclone.domain.video.dto.VideoUploadDto;
 import com.semtleWebGroup.youtubeclone.domain.video.repository.VideoRepository;
 import com.semtleWebGroup.youtubeclone.domain.video.service.VideoService;
 import com.semtleWebGroup.youtubeclone.domain.video_media.service.MediaServerSpokesman;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.MockedMediaServerSpokesman;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.ProdMediaServerSpokesman;
 import com.semtleWebGroup.youtubeclone.test_super.MockTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +29,7 @@ public class VideoServiceTest extends MockTest {
     @BeforeAll
     public static void set() {
         videoRepository = Mockito.mock(VideoRepository.class);
-        mediaServerSpokesman = Mockito.mock(MediaServerSpokesman.class);
+        mediaServerSpokesman = Mockito.mock(MockedMediaServerSpokesman.class);
         videoService = new VideoService(videoRepository, mediaServerSpokesman);
     }
 

--- a/src/test/java/com/semtleWebGroup/youtubeclone/domain/video_media/aop/MediaServerApiLoggerTest.java
+++ b/src/test/java/com/semtleWebGroup/youtubeclone/domain/video_media/aop/MediaServerApiLoggerTest.java
@@ -1,0 +1,36 @@
+package com.semtleWebGroup.youtubeclone.domain.video_media.aop;
+
+import com.semtleWebGroup.youtubeclone.domain.video_media.dto.response.GetEncodingStatusResponse;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.MediaServerSpokesman;
+import com.semtleWebGroup.youtubeclone.domain.video_media.service.MockedMediaServerSpokesman;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class MediaServerApiLoggerTest {
+    @Autowired
+    private MediaServerSpokesman mediaServerSpokesman;
+
+    @Test
+    void instanceTest() throws Throwable {
+        // 프록시를 테스트 하는 방법을 모르겠음
+        Assertions.assertInstanceOf(MockedMediaServerSpokesman.class, mediaServerSpokesman);
+        GetEncodingStatusResponse.EncodingStatus encodingStatus = mediaServerSpokesman.getEncodingStatus(UUID.randomUUID());
+        System.out.println(encodingStatus);
+    }
+
+}


### PR DESCRIPTION
# 변경 유형

- [x] 기능 추가
- [ ] 성능 개선 ( 리팩토링 )
- [ ] 오류 수정
- [ ] Test Case 추가
- [ ] 기타 (document, 환경설정, CI/CD )

# 변경 내용
- 미디어 서버와의 연결 구현
- prod 설정시 시스템 환경변수 `media-server-url`을 통해 설정하는기능
- aop를 통해 로깅하는 기능
- media server spokesman을 인터페이스로 바꾸고 구현체를 분리해서, prod가 아닌 환경에서 mocked 구현체가 주입 되도록 설정

# 참조 자료
- #53 

Closes #53 