### PR TITLE
[ADD] login 기능 긴급 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,15 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+	// jwt
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/api/AuthApi.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/api/AuthApi.java
@@ -1,0 +1,132 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.api;
+
+
+import com.semtleWebGroup.youtubeclone.domain.auth.dao.MemberRepository;
+import com.semtleWebGroup.youtubeclone.domain.auth.domain.Member;
+import com.semtleWebGroup.youtubeclone.domain.auth.domain.Role;
+import com.semtleWebGroup.youtubeclone.domain.auth.dto.ChannelCandidateResponse;
+import com.semtleWebGroup.youtubeclone.domain.auth.dto.FormBody;
+import com.semtleWebGroup.youtubeclone.domain.auth.exception.common.OccupiedEmailException;
+import com.semtleWebGroup.youtubeclone.domain.auth.token.AccessToken;
+import com.semtleWebGroup.youtubeclone.global.error.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AuthApi {
+
+    private final AccessToken.TokenBuilder tokenBuilder;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @PostMapping("/auth/login")
+    public ResponseEntity<ChannelCandidateResponse> login(@Valid @RequestBody FormBody formBody) {
+        //1. db 조회
+        Member member = memberRepository.findByEmail(formBody.getEmail());
+
+        if (member == null) {
+            log.debug("try login with unknown email {} ", formBody.getEmail());
+            throw new BadCredentialsException("email not found");
+        }
+
+        //2. 비밀번호 확인
+        boolean matches = passwordEncoder.matches(formBody.getPassword(), member.getPassword());
+        if (!matches) {
+            log.debug("try login with wrong password");
+            throw new BadCredentialsException("password not found");
+        }
+
+        //3. 토큰 생성
+        AccessToken accessToken = tokenBuilder.build(member);
+        log.debug("login success and token published");
+
+        //4. 채널 리스트 바디 생성
+        List<ChannelCandidateResponse.Entry> entries = member.getChannels().stream()
+                .map(channel -> new ChannelCandidateResponse.Entry(channel.getTitle(), channel.getId()))
+                .collect(Collectors.toList());
+        ChannelCandidateResponse channelCandidateResponse = new ChannelCandidateResponse(entries);
+
+        //4. 토큰 응답
+        return ResponseEntity.ok()
+                .header("Authorization", "Bearer  " + accessToken.getValue())
+                .body(channelCandidateResponse);
+    }
+
+
+    @PostMapping("/auth/channel")
+    public ResponseEntity<Void> channel(@RequestBody Map<String, String> requestBody, @RequestHeader("Authorization") String authorization) {
+        //1. valid request
+        boolean isHeaderValid = StringUtils.hasText(authorization) && authorization.startsWith("Bearer ");
+        boolean isBodyValid = requestBody.containsKey("key");
+        if (!isHeaderValid || !isBodyValid) {
+            throw new BadRequestException(Collections.emptyList());
+        }
+
+        //2. 토큰 파싱
+        String tokenValue = authorization.substring(7);
+        AccessToken token = tokenBuilder.build(tokenValue);
+        Map<AccessToken.Field, String> fieldStringMap = token.parseClaims();
+        Long memberId = Long.valueOf(fieldStringMap.get(AccessToken.Field.MEMBER_ID));
+
+        //3. body 파싱
+        Long wantedChannelId = Long.valueOf(requestBody.get("key"));
+
+        //4. 원하는 채널 아이디가 유효한지 확인
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new BadCredentialsException("token claim - memberId is not valid"));
+        boolean isValidChannelId = member.getChannels().stream().anyMatch(channel -> channel.getId().equals(wantedChannelId));
+
+        if (!isValidChannelId){
+            throw new BadRequestException(Collections.emptyList());
+        }
+
+        //5. 토큰에 channelId 넣어서 재생성
+        AccessToken newToken = tokenBuilder.build(member, wantedChannelId);
+
+        //6. 토큰 응답
+        log.debug("token event - channel changed");
+        return ResponseEntity.ok()
+                .header("Authorization", "Bearer  " + newToken.getValue())
+                .build();
+    }
+
+    @PostMapping("/auth/logout")
+    public ResponseEntity<Void> logout() {
+        //그냥 간단하게, 토큰 없에서 리턴
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/auth/register")
+    public ResponseEntity<Void> register(@Valid @RequestBody FormBody formBody) {
+        //1. db 저장
+        Member member = new Member(formBody.getEmail(), passwordEncoder.encode(formBody.getPassword()), Role.ROLE_USER, List.of());
+        try {
+            memberRepository.save(member);
+        } catch (DataIntegrityViolationException e){
+            if (e.getMessage().toUpperCase().contains("member_email_unique".toUpperCase())){
+                throw new OccupiedEmailException("occupied email "+ formBody.getEmail()); //handled by Global Exception Handler
+            } else {
+                throw e;
+            }
+        }
+        log.debug("register success");
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/config/AuthProperties.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/config/AuthProperties.java
@@ -1,0 +1,36 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.config;
+
+import io.jsonwebtoken.security.WeakKeyException;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "auth")
+public class AuthProperties implements InitializingBean {
+
+    private final String DEFAULT_SECRET = "asdlfkjldfksjflsdkajsldkfjasdfasfasdfasdfasdfasd";
+
+    private Long tokenExpirationMsec = 864000000L; // 10 days
+    private String secretKey = DEFAULT_SECRET;
+
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        if (secretKey.equals(DEFAULT_SECRET)) {
+            log.info("secret key is default value. this is not recommended on production server. please change secret key.");
+        }
+        if (secretKey.length() < 32) {
+            // 어플리 케이션 실행을 종료시킴
+            throw new IllegalArgumentException("secret key length is less than 256 bits (32 bytes) as mandated by the JWT JWA Specification (RFC 7518, Section 3.2)");
+        }
+        log.error("if the key byte array length is less than 256 bits (32 bytes) as mandated by the JWT JWA Specification (RFC 7518, Section 3.2) ");
+
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/config/SecurityConfig.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/config/SecurityConfig.java
@@ -1,0 +1,82 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.config;
+
+import com.semtleWebGroup.youtubeclone.domain.auth.dao.MemberRepository;
+import com.semtleWebGroup.youtubeclone.domain.auth.domain.Member;
+import com.semtleWebGroup.youtubeclone.domain.auth.domain.Role;
+import com.semtleWebGroup.youtubeclone.domain.auth.exception.GlobalAuthFailEntryPoint;
+import com.semtleWebGroup.youtubeclone.domain.auth.filter.JwtAuthorizationFilter;
+import com.semtleWebGroup.youtubeclone.domain.auth.token.AccessToken;
+import com.semtleWebGroup.youtubeclone.domain.channel.domain.Channel;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.util.Base64;
+import java.util.List;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AccessToken.TokenBuilder accessTokenBuilder(AuthProperties authProperties) {
+        return AccessToken.builder(Base64.getEncoder().encodeToString(authProperties.getSecretKey().getBytes()), authProperties.getTokenExpirationMsec(), SignatureAlgorithm.HS256);
+    }
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity security, AccessToken.TokenBuilder tokenBuilder) throws Exception {
+
+        // disables
+        return security
+                .httpBasic().disable()
+                .formLogin().disable()
+                .csrf().disable()
+                .cors().disable()
+                .formLogin().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests(req -> req
+                        .antMatchers("/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling()
+                .authenticationEntryPoint(new GlobalAuthFailEntryPoint())
+                .and()
+                //jwt authorization
+                .addFilterBefore(new JwtAuthorizationFilter(tokenBuilder), BasicAuthenticationFilter.class)
+                .build();
+
+    }
+
+
+    @Bean
+    public CommandLineRunner testMemberInitializer(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
+        return args -> {
+            Channel channel1 = Channel.builder()
+                    .title("channel1")
+                    .description("channel1 des")
+                    .build();
+            Channel channel2 = Channel.builder()
+                    .title("channel2")
+                    .description("channel2 des")
+                    .build();
+
+            Member member = new Member("test@a.a", passwordEncoder.encode("1234"), Role.ROLE_USER, List.of(channel1, channel2));
+            memberRepository.save(member);
+        };
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dao/MemberRepository.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dao/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.dao;
+
+import com.semtleWebGroup.youtubeclone.domain.auth.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    public Member findByEmail(String email);
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/domain/Member.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/domain/Member.java
@@ -1,0 +1,50 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.domain;
+
+import com.semtleWebGroup.youtubeclone.domain.channel.domain.Channel;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"email"},name = "member_email_unique"))
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", updatable = false)
+    Long id;
+
+    @NotNull
+    @Email
+    @Column(name = "email", nullable = false)
+    String email;
+
+    @Column(name = "password",nullable = false)
+    String password;
+
+    @Column(name = "role",nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "member_id")
+    private List<Channel> channels = new ArrayList<>();
+
+
+    public Member(String email, String password, Role role, List<Channel> channels) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.channels = channels;
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/domain/Role.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/domain/Role.java
@@ -1,0 +1,4 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.domain;
+public enum Role {
+    ROLE_USER, ROLE_ADMIN;
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/domain/TokenStatus.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/domain/TokenStatus.java
@@ -1,0 +1,5 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.domain;
+
+public enum TokenStatus {
+    VALID, INVALID, EXPIRED;
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dto/ChannelCandidateResponse.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dto/ChannelCandidateResponse.java
@@ -1,0 +1,29 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelCandidateResponse {
+
+    private List<Entry> users;
+
+    public ChannelCandidateResponse(List<Entry> users) {
+        this.users = users;
+    }
+
+    @Getter
+    public static class Entry {
+        private final String name;
+        private final Long key;
+
+        public Entry(String name, Long key) {
+            this.name = name;
+            this.key = key;
+        }
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dto/CustomAuthentication.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dto/CustomAuthentication.java
@@ -1,0 +1,63 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.dto;
+
+import com.semtleWebGroup.youtubeclone.domain.auth.token.AccessToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CustomAuthentication implements Authentication {
+    private final Map<AccessToken.Field, String> map;
+    private boolean authenticated = true;
+
+    public CustomAuthentication(Map<AccessToken.Field, String> map) {
+        this.map = map;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> collect = Stream.of(map.get(AccessToken.Field.ROLE))
+                .map(r -> new GrantedAuthority() {
+                    @Override
+                    public String getAuthority() {
+                        return r;
+                    }
+                })
+                .collect(Collectors.toList());
+        return collect;
+    }
+
+    @Override
+    public Object getCredentials() {
+        throw new UnsupportedOperationException("Not supported yet");
+    }
+
+    @Override
+    public Object getDetails() {
+        throw new UnsupportedOperationException("Not supported yet");
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return TokenInfo.of(map);
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return authenticated;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        this.authenticated = isAuthenticated;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dto/FormBody.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dto/FormBody.java
@@ -1,0 +1,19 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FormBody{
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dto/TokenInfo.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/dto/TokenInfo.java
@@ -1,0 +1,30 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.dto;
+
+import com.semtleWebGroup.youtubeclone.domain.auth.domain.Role;
+import com.semtleWebGroup.youtubeclone.domain.auth.token.AccessToken;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class TokenInfo {
+    private final String email;
+    private final Role role;
+    private final Long userId;
+    private final Long channelId;
+
+    public TokenInfo(String email, Role role, Long userId, Long channelId) {
+        this.email = email;
+        this.role = role;
+        this.userId = userId;
+        this.channelId = channelId;
+    }
+    public static TokenInfo of (Map<AccessToken.Field,String> map){
+        return new TokenInfo(
+                map.get(AccessToken.Field.EMAIL),
+                Role.valueOf(map.get(AccessToken.Field.ROLE)),
+                Long.valueOf(map.get(AccessToken.Field.MEMBER_ID)),
+                Long.valueOf(map.get(AccessToken.Field.CHANNEL_ID))
+        );
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/exception/GlobalAuthFailEntryPoint.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/exception/GlobalAuthFailEntryPoint.java
@@ -1,0 +1,20 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+public class GlobalAuthFailEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.info("인증 실패");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        //TODO : 인증 실패 예외를 세분화 하여 처리
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/exception/common/OccupiedEmailException.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/exception/common/OccupiedEmailException.java
@@ -1,0 +1,10 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.exception.common;
+
+import com.semtleWebGroup.youtubeclone.global.error.ErrorCode;
+import com.semtleWebGroup.youtubeclone.global.error.exception.BusinessException;
+
+public class OccupiedEmailException extends BusinessException {
+    public OccupiedEmailException(String message) {
+        super(message, ErrorCode.OCCUPIED_EMAIL);
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/exception/token/TokenAbsentException.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/exception/token/TokenAbsentException.java
@@ -1,0 +1,9 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.exception.token;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class TokenAbsentException extends AuthenticationException {
+    public TokenAbsentException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/exception/token/TokenExpiredException.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/exception/token/TokenExpiredException.java
@@ -1,0 +1,9 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.exception.token;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class TokenExpiredException extends AuthenticationException {
+    public TokenExpiredException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,94 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.filter;
+
+import com.semtleWebGroup.youtubeclone.domain.auth.dto.CustomAuthentication;
+import com.semtleWebGroup.youtubeclone.domain.auth.exception.token.TokenAbsentException;
+import com.semtleWebGroup.youtubeclone.domain.auth.exception.token.TokenExpiredException;
+import com.semtleWebGroup.youtubeclone.domain.auth.token.AccessToken;
+import com.semtleWebGroup.youtubeclone.domain.auth.token.Token;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * 모든 인증이 필요한 요청을 가로막는 필터
+ */
+@Slf4j
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+    private final AccessToken.TokenBuilder accessTokenBuilder;
+    public JwtAuthorizationFilter(AccessToken.TokenBuilder accessTokenBuilder) {
+        this.accessTokenBuilder = accessTokenBuilder;
+
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        //1. check request is contain token
+        AccessToken accessToken;
+        try {
+            accessToken = this.resolveToken(request);
+        } catch (TokenAbsentException e) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //2. check token
+
+        Token.TokenStatus tokenStatus = accessToken.validateToken();
+        if (tokenStatus.equals(Token.TokenStatus.VALID)) {
+            log.debug("The token passed to the request that requires authentication is valid ( {} ).",request.getRequestURI());
+        } else if (tokenStatus.equals(Token.TokenStatus.INVALID)){
+            log.debug("The token passed to the request that requires authentication is invalid ( {} ).",request.getRequestURI());
+            throw new BadCredentialsException("token is invalid");
+        } else if (tokenStatus.equals(Token.TokenStatus.EXPIRED)) {
+            throw new TokenExpiredException("token is expired");
+        }
+
+        //3. parse token
+        Map<AccessToken.Field, String> map = accessToken.parseClaims();
+
+        //4. check channelId
+        if (!StringUtils.hasText(map.get(AccessToken.Field.CHANNEL_ID))) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //5. set Authentication
+        CustomAuthentication customAuthentication = new CustomAuthentication(map);
+        SecurityContextHolder.getContext().setAuthentication(customAuthentication);
+
+        filterChain.doFilter(request, response);
+
+    }
+
+
+    protected AccessToken resolveToken(HttpServletRequest request) throws TokenAbsentException {
+
+        boolean hasToken = false;
+
+        // 1. extract token from header
+        String authorization = request.getHeader("Authorization");
+        String token = null;
+        if (StringUtils.hasText(authorization) && authorization.startsWith("Bearer ")) {
+            token = authorization.substring(7);
+            hasToken = true;
+        }
+
+        // 2. check
+        if (!hasToken || !StringUtils.hasText(token)) {
+            throw new TokenAbsentException("token is empty");
+        }
+
+
+        // 3. made it AccessToken and return
+        return accessTokenBuilder.build(token);
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/token/AccessToken.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/token/AccessToken.java
@@ -1,0 +1,95 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.token;
+
+import com.semtleWebGroup.youtubeclone.domain.auth.domain.Member;
+import com.semtleWebGroup.youtubeclone.domain.auth.util.AES256;
+import io.jsonwebtoken.*;
+import org.springframework.util.StringUtils;
+
+import java.util.Date;
+import java.util.Map;
+
+public class AccessToken extends Token {
+    public enum Field {
+        EMAIL,
+        ROLE,
+        MEMBER_ID,
+        CHANNEL_ID
+    }
+
+
+    private AccessToken(String value, String tokenSecretKey, SignatureAlgorithm signatureAlgorithm) {
+        super(value, tokenSecretKey, signatureAlgorithm);
+    }
+
+    public static TokenBuilder builder(String tokenSecretKey, Long accessTokenExpirationMsec, SignatureAlgorithm signatureAlgorithm){
+        return new TokenBuilder(tokenSecretKey, accessTokenExpirationMsec, signatureAlgorithm);
+    }
+
+    /**
+     * 토큰을 쉽게 생성하기 위한 Builder Pattern
+     */
+    public static class TokenBuilder {
+        private final String tokenSecretKey;
+        private final Long accessTokenExpirationMsec;
+        private final SignatureAlgorithm signatureAlgorithm;
+
+        public TokenBuilder(String tokenSecretKey, Long accessTokenExpirationMsec, SignatureAlgorithm signatureAlgorithm) {
+            this.tokenSecretKey = tokenSecretKey;
+            this.accessTokenExpirationMsec = accessTokenExpirationMsec;
+            this.signatureAlgorithm = signatureAlgorithm;
+        }
+
+        public AccessToken build(Member member, Long channelId){
+            Date now = new Date();
+            Date expiryDate = new Date(now.getTime() + accessTokenExpirationMsec);
+
+            String encryptMemberId = AES256.encrypt(member.getId().toString());
+            String encryptChannelId = "";
+            if (channelId != null) {
+                encryptChannelId = AES256.encrypt(channelId.toString());
+            }
+
+
+            String value = Jwts.builder()
+                    .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                    .setSubject(TokenType.ACCESS_TOKEN.name())
+                    .setIssuedAt(now)
+                    .setExpiration(expiryDate)
+                    .claim(Field.EMAIL.name(), member.getEmail().toString())
+                    .claim(Field.ROLE.name(), member.getRole().name())
+                    .claim(Field.MEMBER_ID.name(), encryptMemberId)
+                    .claim(Field.CHANNEL_ID.name(), encryptChannelId)
+                    .signWith(signatureAlgorithm, tokenSecretKey)
+                    .compact();
+            return new AccessToken(value, tokenSecretKey,signatureAlgorithm);
+        }
+
+
+        public AccessToken build(Member member){
+            return this.build(member, null);
+        }
+
+        public AccessToken build(String token){
+            return new AccessToken(token, tokenSecretKey,signatureAlgorithm);
+        }
+    }
+
+    @Override
+    public Map<Field, String> parseClaims() {
+        Map<Field, String> fieldStringMap = super.parseClaims();
+        //decrypt
+        String encryptMemberId = fieldStringMap.get(Field.MEMBER_ID);
+        String encryptChannelId = fieldStringMap.get(Field.CHANNEL_ID);
+
+        String memberId = AES256.decrypt(encryptMemberId);
+        String channelId = "";
+        if (StringUtils.hasText(encryptChannelId)) channelId = AES256.decrypt(encryptChannelId);
+
+        //replace entry
+        fieldStringMap.replace(Field.MEMBER_ID, memberId);
+        fieldStringMap.replace(Field.CHANNEL_ID, channelId);
+
+        return fieldStringMap;
+
+    }
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/token/Token.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/token/Token.java
@@ -1,0 +1,78 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.token;
+
+import io.jsonwebtoken.*;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Slf4j
+@EqualsAndHashCode(of = "value")
+public abstract class Token {
+
+    public enum TokenStatus {
+        VALID,
+        INVALID,
+        EXPIRED
+    }
+
+    public enum TokenType {
+        ACCESS_TOKEN,
+        REFRESH_TOKEN
+    }
+
+    protected String value;
+
+    private final JwtParser jwtParser;
+    private final SignatureAlgorithm signatureAlgorithm;
+
+    public Token(String value, String tokenSecretKey, SignatureAlgorithm signatureAlgorithm) {
+        this.value = value;
+        this.jwtParser = Jwts.parserBuilder().setSigningKey(tokenSecretKey).build();
+        this.signatureAlgorithm = signatureAlgorithm;
+    }
+
+    public Map<AccessToken.Field,String> parseClaims(){
+        Claims body = jwtParser
+                .parseClaimsJws(this.value).getBody();
+
+        Map<AccessToken.Field,String> claims = new HashMap<>();
+        for (AccessToken.Field field : AccessToken.Field.values()){
+            claims.put(field, body.get(field.name(), String.class));
+        }
+        return claims;
+    }
+
+
+    public Token.TokenStatus validateToken() {
+        try {
+            this.parseClaims();
+            return Token.TokenStatus.VALID;
+        } catch (SignatureException e){
+            log.debug("{} >> invalid signature : claimsJwt string is actually a JWS and signature validation fails",this.getClass().getName());
+            return Token.TokenStatus.INVALID;
+        } catch (MalformedJwtException e){
+            log.debug("{} >> invalid claimsJwt : the Jwt is not a valid",this.getClass().getName());
+            return Token.TokenStatus.INVALID;
+        } catch (ExpiredJwtException e) {
+            log.debug("{} >> expired claimsJwt : the Jwt is expired", this.getClass().getName());
+            return Token.TokenStatus.EXPIRED;
+        } catch (UnsupportedJwtException e) {
+            log.debug("{} >> unsupported claimsJwt : the claimsJwt argument does not represent an unsigned Claims JWT",this.getClass().getName());
+            return Token.TokenStatus.INVALID;
+        }
+    }
+
+
+
+    public String getValue() {
+        return value;
+    }
+
+    protected void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/util/AES256.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/auth/util/AES256.java
@@ -1,0 +1,48 @@
+package com.semtleWebGroup.youtubeclone.domain.auth.util;
+
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class AES256 {
+
+    public static String alg = "AES/CBC/PKCS5Padding";
+    private static final String key = "01234567890123456789012345678901";
+    private static final String iv = key.substring(0, 16); // 16byte
+
+    public static String encrypt(String text) {
+        byte[] encrypted;
+        try {
+
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(), "AES");
+            IvParameterSpec ivParamSpec = new IvParameterSpec(iv.getBytes());
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivParamSpec);
+
+            encrypted = cipher.doFinal(text.getBytes("UTF-8"));
+        } catch (Exception e){
+            throw new IllegalStateException("암호화 에러");
+        }
+        return Base64.getEncoder().encodeToString(encrypted);
+    }
+
+
+    public static String decrypt(String cipherText) {
+        String result;
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(), "AES");
+            IvParameterSpec ivParamSpec = new IvParameterSpec(iv.getBytes());
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivParamSpec);
+
+            byte[] decodedBytes = Base64.getDecoder().decode(cipherText);
+            byte[] decrypted = cipher.doFinal(decodedBytes);
+            result = new String(decrypted, "UTF-8");
+        } catch (Exception e){
+            throw new IllegalStateException("복호화 에러");
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/com/semtleWebGroup/youtubeclone/domain/channel/domain/Channel.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/domain/channel/domain/Channel.java
@@ -3,6 +3,7 @@ package com.semtleWebGroup.youtubeclone.domain.channel.domain;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.semtleWebGroup.youtubeclone.domain.auth.domain.Member;
 import com.semtleWebGroup.youtubeclone.domain.comment.domain.Comment;
 import com.semtleWebGroup.youtubeclone.domain.video.domain.Video;
 import lombok.*;

--- a/src/main/java/com/semtleWebGroup/youtubeclone/global/error/ErrorCode.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/global/error/ErrorCode.java
@@ -13,8 +13,11 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"C005","Internal Server Error"),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND,"C006","Entity Not Found" ),
 
-    //local file system
-    VIDEO_NOT_EXIST(HttpStatus.NOT_FOUND,"L001","Video File Not Exist");
+    OCCUPIED_EMAIL(HttpStatus.CONFLICT,"C007","Occupied Email");
+
+
+
+
 
 
     private String message;

--- a/src/main/java/com/semtleWebGroup/youtubeclone/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/semtleWebGroup/youtubeclone/global/error/GlobalExceptionHandler.java
@@ -6,7 +6,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -136,6 +138,17 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response,errorCode.getStatus());
     }
 
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    protected ResponseEntity<?> handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e){
+        log.error("handleHttpMediaTypeNotSupportedException",e);
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).build();
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    protected ResponseEntity<?> handleBadCredentialsException(BadCredentialsException e){
+        log.error("handleBadCredentialsException",e);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
 
 
     /**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,3 +17,6 @@ spring:
 logging:
   level:
     root: debug
+auth:
+  secret-key: secretadsfsdfsdfasdfasdfasdfasdfaasdfasdfasdfasdfasdfasdfaf
+  token-expiration-msec: 864000000


### PR DESCRIPTION
# 변경 유형

- [x] 기능 추가
- [ ] 성능 개선 ( 리팩토링 )
- [ ] 오류 수정
- [ ] Test Case 추가
- [ ] 기타 (document, 환경설정, CI/CD )

# 변경 내용
- 

# 참조 자료
.
├── auth
│   ├── api
│   │   └── AuthApi.java #로그인, 회원가입, 로그아웃 등
│   ├── config
│   │   ├── AuthProperties.java # property 세팅 관련, 환경 변수 검증, 초깃값 세팅
│   │   └── SecurityConfig.java # spring security 관련 설정, 필터 등록
│   ├── dao
│   │   └── MemberRepository.java
│   ├── domain
│   │   ├── Member.java # 📍 멤버 Entity << 우재님 수정하실때 참고
│   │   ├── Role.java # 역할 enum
│   │   └── TokenStatus.java # 토큰의 상태 enum, 토큰 검증을 좀 더 젠틀하게 처리하기 위해
│   ├── dto
│   │   ├── ChannelCandidateResponse.java # 로그인 이후, 채널 선택 리스트를 주기 위해
│   │   ├── CustomAuthentication.java # 이건, 대충 필수만 구현을 해서, getPrincipal만 사용가능합니다.
│		│   │                             # 구현 안된 메서드를 호출하면 예외발생, 근데 위의 예시대로 호출하면, 쓸일 없음
│   │   ├── FormBody.java # 로그인, 회원가입용 JSON Body 매핑용
│   │   └── TokenInfo.java # 📍 위의 예시처럼 받으면 이걸 받게 됩니다.
│   ├── exception
│   │   ├── GlobalAuthFailEntryPoint.java # 인증 실패(토큰 잘못됨, 만료됨) 핸들러, 추후 세밀하게 처리 가능
│   │   ├── common
│   │   │   └── OccupiedEmailException.java # 가입된 이메일로 회원가입, GlobalExcepitonHandler에서 처리됨
│   │   └── token
│   │       ├── TokenAbsentException.java # 토큰 없음 예외 AuthenticationException 자손
│   │       └── TokenExpiredException.java # 토큰 만료됨 예외 AuthenticationException 자손
│   ├── filter
│   │   └── JwtAuthorizationFilter.java # 📍 모든 요청에서 JWT헤더가 있으면, 인증 시도 하는 필터
│   ├── token
│   │   ├── AccessToken.java # Token의 자손,Access 토큰을 추상화함, 많은 메서드 제공
│   │   └── Token.java # 추상 클래스, Token을 추상화함.
│   └── util
│       └── AES256.java # JWT에서 memberId와 ChannelId를 생으로 노출하기 싫어서 대칭 키로 암호화 복호화 하게함. 그 유틸 객체
├── channel
├── comment
├── video
└── video_media